### PR TITLE
Modifies GraphSender to use Upload Session

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# Fork of NatchEurope/FluentEmail.Graph
+
+Fork of [NatchEurope/FluentEmail.Graph](https://github.com/NatchEurope/FluentEmail.Graph) that modifies the `GraphSender` to use an upload session for sending emails with attachments that are 3MB or larger. I was receiving a Microsoft Graph API error when trying to use FluentEmail.Graph to send emails with attachments over 3MB.
+
+[Microsoft Docs on using the Graph API to send large attachments](https://docs.microsoft.com/en-us/graph/outlook-large-attachments?tabs=csharp)
+
+Unfortunately, the Microsoft Graph API `Send` method does not have a `SaveSentItems` argument like the `SendMail` method does, so I had to remove the option to disable saving sent items. See [Link 1](https://docs.microsoft.com/en-us/answers/questions/337574/graph-sdk-i-want-to-send-the-saved-draft-mail-but.html), [Link 2](https://docs.microsoft.com/en-us/graph/api/message-send?view=graph-rest-1.0&tabs=http), and [Link 3](https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/743).
+
 # FluentEmail.Graph
 
 Sender for [FluentEmail](https://github.com/lukencode/FluentEmail) that uses [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/api/resources/mail-api-overview?view=graph-rest-1.0).
@@ -29,7 +37,6 @@ Example config in `appsettings.json`
     "AppId": "your app id",
     "TenantId": "your tenant id",
     "Secret": "your secret here",
-    "SaveSentItems": true
   }
 }
 ```

--- a/src/FluentEmail.Graph/FluentEmailServicesBuilderExtensions.cs
+++ b/src/FluentEmail.Graph/FluentEmailServicesBuilderExtensions.cs
@@ -21,15 +21,13 @@
             this FluentEmailServicesBuilder builder,
             string graphEmailClientId,
             string graphEmailTenantId,
-            string graphEmailSecret,
-            bool saveSentItems = false)
+            string graphEmailSecret)
         {
             var options = new GraphSenderOptions
             {
                 ClientId = graphEmailClientId,
                 TenantId = graphEmailTenantId,
                 Secret = graphEmailSecret,
-                SaveSentItems = saveSentItems,
             };
             return builder.AddGraphSender(options);
         }

--- a/src/FluentEmail.Graph/GraphSenderOptions.cs
+++ b/src/FluentEmail.Graph/GraphSenderOptions.cs
@@ -19,10 +19,5 @@
         /// Gets or sets the secret string previously shared with AAD at application registration to prove the identity of the application (the client) requesting the tokens.
         /// </summary>
         public string Secret { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to save the message in Sent Items. Default is <c>true</c>.
-        /// </summary>
-        public bool? SaveSentItems { get; set; }
     }
 }


### PR DESCRIPTION
I was receiving a Microsoft Graph API error when trying to use FluentEmail.Graph to send emails with attachments over 3MB. So, I created a fork of [NatchEurope/FluentEmail.Graph](https://github.com/NatchEurope/FluentEmail.Graph) that modifies the `GraphSender` to use an upload session for sending emails with attachments that are 3MB or larger. 

Unfortunately, the Microsoft Graph API `Send` method does not have a `SaveSentItems` argument like the `SendMail` method does, so I had to remove the option to disable saving sent items. See [Link 1](https://docs.microsoft.com/en-us/answers/questions/337574/graph-sdk-i-want-to-send-the-saved-draft-mail-but.html), [Link 2](https://docs.microsoft.com/en-us/graph/api/message-send?view=graph-rest-1.0&tabs=http), and [Link 3](https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/743).

You probably won't want to merge this into your project since you will lose the `SaveSentItems` argument. But you can use/reference my code if you do decide to modify the project to use upload sessions. Or at the very least others can use my fork if they need to send emails with larger attachments.

I have opened issue #84 