### PR TITLE
Allow GraphServiceClient to be passed in

### DIFF
--- a/src/FluentEmail.Graph/FluentEmailServicesBuilderExtensions.cs
+++ b/src/FluentEmail.Graph/FluentEmailServicesBuilderExtensions.cs
@@ -3,6 +3,7 @@
     using FluentEmail.Core.Interfaces;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection.Extensions;
+    using Microsoft.Graph;
 
     /// <summary>
     /// Contains extension methods to register the <see cref="GraphSender"/> with the <c>FluentEmailServicesBuilder</c> from <c>FluentEmail.Core</c>.
@@ -30,6 +31,14 @@
                 Secret = graphEmailSecret,
             };
             return builder.AddGraphSender(options);
+        }
+
+        public static FluentEmailServicesBuilder AddGraphSender(
+            this FluentEmailServicesBuilder builder,
+            GraphServiceClient graphClient)
+        {
+            builder.Services.TryAdd(ServiceDescriptor.Scoped<ISender>(_ => new GraphSender(graphClient)));
+            return builder;
         }
     }
 }

--- a/src/FluentEmail.Graph/GraphSender.cs
+++ b/src/FluentEmail.Graph/GraphSender.cs
@@ -31,6 +31,11 @@
             this.graphClient = new (spn);
         }
 
+        public GraphSender(GraphServiceClient graphClient)
+        {
+            this.graphClient = graphClient;
+        }
+
         public SendResponse Send(IFluentEmail email, CancellationToken? token = null)
         {
             return this.SendAsync(email, token)


### PR DESCRIPTION
Simple changes to allow a GraphServiceClient instance to be passed in via a new AddGraphSender() signature re #142 .  Let me know what you think - thanks!  