### PR TITLE
📝 chore: Update Attribution in <authors> Tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,3 @@ Create new release with creation of new tag on main branch.
 Start [publish](https://github.com/ESC-BV/FluentEmail.Graph/actions/workflows/publish.yml) manually, for the new tag.
 This will push the package to github and nuget.org
 
-## Origin
-
-Code originally written by [Matt Goldman](https://github.com/matt-goldman)
-and [merged](https://github.com/lukencode/FluentEmail/pull/218) into FluentEmail repo. But it was not published to NuGet
-until January 2021. Because we needed this implementation we created a separate repo, modified the code a bit and
-published it to NuGet.

--- a/src/FluentEmail.Graph/FluentEmail.Graph.csproj
+++ b/src/FluentEmail.Graph/FluentEmail.Graph.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <Authors>David De Sloovere</Authors>
+        <Authors>David De Sloovere, Matt Goldman</Authors>
         <Owner>ESC</Owner>
         <Company>ESC</Company>
         <Description>Sender for FluentEmail that uses Microsoft Graph API. Implements `FluentEmail.Core.Interfaces.ISender`.</Description>


### PR DESCRIPTION
Hey there,

First off, big thanks for giving a shoutout in the readme! 🙌 However, I think that probably doesn't need to be there - the common approach to providing attribution is usually through the `<authors>` tag. This PR follows that convention and clears up that bit at the bottom of the readme.

Hope this is cool with you 🙂

Cheers