### PR TITLE
chore: bump package versions to support .NET 8

### DIFF
--- a/sample/SendMailTestApp/SendMailTestApp.csproj
+++ b/sample/SendMailTestApp/SendMailTestApp.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/FluentEmail.Graph/FluentEmail.Graph.csproj
+++ b/src/FluentEmail.Graph/FluentEmail.Graph.csproj
@@ -40,17 +40,17 @@ v2.1 Added support for Inline images
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.8.2"/>
+        <PackageReference Include="Azure.Identity" Version="1.10.4" />
         <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentEmail.Core" Version="3.0.2"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2023.2.0">
+        <PackageReference Include="FluentEmail.Core" Version="3.0.2" />
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Graph" Version="5.7.0"/>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+        <PackageReference Include="Microsoft.Graph" Version="5.37.0" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/FluentEmail.Graph.Tests/FluentEmail.Graph.Tests.csproj
+++ b/tests/FluentEmail.Graph.Tests/FluentEmail.Graph.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">


### PR DESCRIPTION
* Microsoft.Extensions.Hosting 7.0.1 -> 8.0.0
* Azure.Identity 1.8.2 -> 1.10.4
* JetBrains.Annotations 2023.2.0 -> 2023.3.0
* Microsoft.Graph 5.7.0 -> 5.37.0
* Microsoft.SourceLink.GitHub 1.1.1 -> 8.0.0
* Microsoft.NET.Test.Sdk 17.7.2 -> 17.8.0

Close #231 